### PR TITLE
Do not require beberlei/assert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     ],
     "require": {
         "php": ">=5.4",
-        "beberlei/assert": "~2.0",
         "simple-bus/message-bus": "~2.0",
         "doctrine/orm": "~2.2"
     },


### PR DESCRIPTION
That library is not used here. Anyway, it's indirectly required by requiring simple-bus/message-bus