### PR TITLE
Drop support for php 5.4 and 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
 language: php
 
 php:
-  - 5.4
+  - 5.6
+  - 7.0
+  - 7.1
 
 env:
   - DOCTRINE_VERSION: 2.2.*
   - DOCTRINE_VERSION: 2.3.*
   - DOCTRINE_VERSION: 2.4.*
-  - DOCTRINE_VERSION: 2.5.*@dev
+  - DOCTRINE_VERSION: 2.5.*
 
-before_install:
-  - composer selfupdate
+before_script:
+  - composer self-update
   - composer require --no-update doctrine/orm:${DOCTRINE_VERSION}
 
 install:
-  - composer update --prefer-dist
+  - composer install --prefer-dist
 
 script:
   - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.6 || ^7.0",
         "simple-bus/message-bus": "~2.0",
         "doctrine/orm": "~2.2"
     },


### PR DESCRIPTION
- Drop support for php 5.4 and 5.5
- Add travis for php 5.6, 7.0 and 7.1
- Changed doctrine to the stable version

More details https://github.com/SimpleBus/MessageBus/pull/68